### PR TITLE
Fix/rename epsilon

### DIFF
--- a/microsmooth.cpp
+++ b/microsmooth.cpp
@@ -204,7 +204,7 @@ int rdp_filter(int current_value, uint16_t history_RDP[])
 	//Serial.print("a:");Serial.print(a);
 	//Serial.print("b:");Serial.print(b);
 	//Serial.print("c:");Serial.println(c);
-	max_distance = epsilon;
+	max_distance = SMOOTH_EPSILON;
 	max_index = start_index;
 	distance = 0;
 	denom = sq_rt(a*a+b*b);

--- a/microsmooth.h
+++ b/microsmooth.h
@@ -66,8 +66,8 @@ on tuning these parameters.
 #define RDP_LENGTH 7
 #endif
 
-#ifndef epsilon
-#define epsilon 50
+#ifndef SMOOTH_EPSILON
+#define SMOOTH_EPSILON 50
 #endif
 
 /*Kolmogorov Zurbenko Filter-  */


### PR DESCRIPTION
Fixes issue #7, apparently `#define epsilon` conflicts with platformio. Renamed it to solve the issue.